### PR TITLE
docs: fix simple typo, octecs -> octets

### DIFF
--- a/mongol.py
+++ b/mongol.py
@@ -154,7 +154,7 @@ for host in hostnames:
                 		print FWprint
 			
 			filterIP = FWlist[-2]
-			# we only check the first 3 octecs because of variation in the routers depending on
+			# we only check the first 3 octets because of variation in the routers depending on
 			# firewall status
 			# fuck regex's
 			shortip = filterIP.split(".")


### PR DESCRIPTION
There is a small typo in mongol.py.

Should read `octets` rather than `octecs`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md